### PR TITLE
fix: remove `__init__` method

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -23,10 +23,6 @@ class RuleType(Enum):
 
 
 class Filter(str):
-    def __init__(self, filter: str) -> None:
-        super().__init__(filter)
-        self.filter = filter
-
     def to_markdown(self) -> str:
         return f"`{self}`"
 


### PR DESCRIPTION
这里的自定义字符串类只需要添加一些自定义方法，所以直接使用父类 `str` 的初始化方法即可，无需手动实现。