### PR TITLE
fix: continue workflow when autofix by github actions

### DIFF
--- a/.github/workflows/check-and-fix.yml
+++ b/.github/workflows/check-and-fix.yml
@@ -49,7 +49,6 @@ jobs:
           done
 
   check-json:
-    needs: check-forbid
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
如果 github action 自动修复了某些问题，再次推送新的 commit 时，`check-forbid` 步骤不应该阻止后续 `check-json` 和 `fix` 步骤的执行。